### PR TITLE
Fix LaTeX marking of uncovered VDM

### DIFF
--- a/FJ-VDMJ/src/main/java/org/overturetool/vdmj/runtime/SourceFile.java
+++ b/FJ-VDMJ/src/main/java/org/overturetool/vdmj/runtime/SourceFile.java
@@ -290,9 +290,9 @@ public class SourceFile
 				if (start >= p)		// Backtracker produces duplicate tokens
 				{
     				sb.append(line.substring(p, start));
-    				sb.append("!\\notcovered{");
+    				sb.append("(*@\\vdmnotcovered{");
     				sb.append(latexQuote(line.substring(start, end)));
-    				sb.append("}!");	//\u00A3");
+    				sb.append("}@*)");	//\u00A3");
 
     				p = end;
 				}

--- a/FJ-VDMJ4/src/main/java/com/fujitsu/vdmj/runtime/SourceFile.java
+++ b/FJ-VDMJ4/src/main/java/com/fujitsu/vdmj/runtime/SourceFile.java
@@ -289,9 +289,9 @@ public class SourceFile
 				if (start >= p)		// Backtracker produces duplicate tokens
 				{
     				sb.append(line.substring(p, start));
-    				sb.append("!\\notcovered{");
+    				sb.append("(*@\\vdmnotcovered{");
     				sb.append(latexQuote(line.substring(start, end)));
-    				sb.append("}!");	//\u00A3");
+    				sb.append("}@*)");	//\u00A3");
 
     				p = end;
 				}


### PR DESCRIPTION
It looks like VDMJ uses some old version of the vdmlisting package to mark unconvered VDM. If that's intentional, then just ignore/close this pull request.

Using the proposed fix, VDMJ now works with the newest version of the listing. 

[1]: http://mirror.hmc.edu/ctan/macros/latex/contrib/vdmlisting/vdmlisting.sty