### PR TITLE
Correct VDMJC's Main-Class attribute

### DIFF
--- a/FJ-VDMJC4/pom.xml
+++ b/FJ-VDMJC4/pom.xml
@@ -50,7 +50,7 @@
 				<configuration>
 					<archive>
 						<manifestEntries>
-							<Main-Class>org.overturetool.vdmjc.VDMJC</Main-Class>
+							<Main-Class>com.fujitsu.vdmjc.VDMJC</Main-Class>
 							<Implementation-Version>${maven.build.timestamp}</Implementation-Version>
 							<Class-Path>.</Class-Path>
 						</manifestEntries>


### PR DESCRIPTION
The Main-Class attribute in VDMJC's manifest file did not match the intended main class.

Before fix:
```bash
peter@peter-tp:~/git-repos/vdmj/FJ-VDMJC4/target (master)
λ java -jar vdmjc-4.0.0-181113.jar 
Error: Could not find or load main class org.overturetool.vdmjc.VDMJC
```
After fix:
```bash
λ java -jar vdmjc-4.0.0-181113.jar 
Dialect is VDM_SL vdm10
>
```