### PR TITLE
Changed mapper to use class classloader

### DIFF
--- a/FJ-VDMJ4/src/main/java/com/fujitsu/vdmj/mapper/ClassMapper.java
+++ b/FJ-VDMJ4/src/main/java/com/fujitsu/vdmj/mapper/ClassMapper.java
@@ -187,8 +187,8 @@ public class ClassMapper
 	 */
 	private void readMappings() throws Exception
 	{
-		Enumeration<URL> urls = ClassLoader.getSystemResources(configFile);
-		
+		Enumeration<URL> urls = this.getClass().getClassLoader().getResources(configFile);
+
 		while (urls.hasMoreElements())
 		{
 			URL url = urls.nextElement();


### PR DESCRIPTION
When using FMI-VDM check from another project using a spring boot classloader it was not able to find the mapping files.
This fixes the issue.