### PR TITLE
Changes the translate return to the generated file URI

### DIFF
--- a/lsp/src/main/java/workspace/LSPXWorkspaceManager.java
+++ b/lsp/src/main/java/workspace/LSPXWorkspaceManager.java
@@ -274,8 +274,7 @@ public class LSPXWorkspaceManager
 			{
 				if (filemap.containsKey(file))
 				{
-					fileToLaTeX(saveUri, file);
-					responseFile = file;
+					responseFile = fileToLaTeX(saveUri, file);
 				}
 				else
 				{
@@ -291,7 +290,7 @@ public class LSPXWorkspaceManager
 		}
 	}
 	
-	private void fileToLaTeX(File saveUri, File file) throws IOException
+	private File fileToLaTeX(File saveUri, File file) throws IOException
 	{
 		SourceFile source = new SourceFile(file);
 		String texname = file.getName().replaceAll("\\.vdm..$", ".tex");
@@ -300,6 +299,8 @@ public class LSPXWorkspaceManager
 		PrintWriter out = new PrintWriter(outfile);
 		source.printLatexCoverage(out, true, true, false);
 		out.close();
+
+		return outfile;
 	}
 
 	public RPCMessageList translateWord(RPCRequest request, File file, File saveUri)
@@ -323,8 +324,7 @@ public class LSPXWorkspaceManager
 			{
 				if (filemap.containsKey(file))
 				{
-					fileToWord(saveUri, file);
-					responseFile = file;
+					responseFile = fileToWord(saveUri, file);
 				}
 				else
 				{
@@ -340,7 +340,7 @@ public class LSPXWorkspaceManager
 		}
 	}
 
-	private void fileToWord(File saveUri, File file) throws IOException
+	private File fileToWord(File saveUri, File file) throws IOException
 	{
 		SourceFile source = new SourceFile(file);
 		String texname = file.getName().replaceAll("\\.vdm..$", ".doc");
@@ -349,6 +349,8 @@ public class LSPXWorkspaceManager
 		PrintWriter out = new PrintWriter(outfile);
 		source.printWordCoverage(out, true, false);
 		out.close();
+		
+		return  outfile;
 	}
 	
 	public RPCMessageList translateCoverage(RPCRequest request, File file, File saveUri)

--- a/lsp/src/test/java/lsp/TranslateTest.java
+++ b/lsp/src/test/java/lsp/TranslateTest.java
@@ -159,7 +159,7 @@ public class TranslateTest extends LSPTest
 		response = handler.request(request);
 		assertEquals(1, response.size());
 		dump(response.get(0));
-		assertEquals(file.toURI().toString(), response.get(0).getPath("result.uri"));
+		assertEquals(empty.toURI()+"pogtest.tex", response.get(0).getPath("result.uri"));
 
 		for (File f: empty.listFiles())
 		{


### PR DESCRIPTION
Hi Nick,

The same approach to covtbl files can be used to LaTeX and Word generation, when single file is requested.

Cheers,
Hugo