### PR TITLE
Enabled sonatype release

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 /.settings/
 /.project
+target
+.idea

--- a/annotations/pom.xml
+++ b/annotations/pom.xml
@@ -6,9 +6,9 @@
 	<description>Annotations</description>
 	
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -30,9 +30,9 @@
 			<version>4.8.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/annotations2/pom.xml
+++ b/annotations2/pom.xml
@@ -6,9 +6,9 @@
 	<description>Annotations2</description>
 	
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
@@ -30,9 +30,9 @@
 			<version>4.8.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/cmd-plugins/pom.xml
+++ b/cmd-plugins/pom.xml
@@ -3,9 +3,10 @@
 	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 	<modelVersion>4.0.0</modelVersion>
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 	
 	<artifactId>cmd-plugins</artifactId>
@@ -30,9 +31,9 @@
 			<version>4.8.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/dbgp/pom.xml
+++ b/dbgp/pom.xml
@@ -6,9 +6,9 @@
 	<name>DBGP</name>
 
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -32,9 +32,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/dbgpc/pom.xml
+++ b/dbgpc/pom.xml
@@ -5,9 +5,9 @@
 	<name>DBGP Client</name>
 	
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/examples/pdfreader/pom.xml
+++ b/examples/pdfreader/pom.xml
@@ -6,8 +6,9 @@
 
 	<parent>
 		<artifactId>examples</artifactId>
-		<groupId>com.fujitsu</groupId>
-		<version>4.4.5</version><!--UPDATE-->
+		<groupId>dk.au.ece.vdmj</groupId>
+		<version>${revision}${sha1}${changelist}</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<name>PDF Reader</name>
@@ -16,9 +17,9 @@
 
 	<dependencies>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/examples/pom.xml
+++ b/examples/pom.xml
@@ -5,9 +5,10 @@
 	<modelVersion>4.0.0</modelVersion>
 
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
+		<relativePath>../pom.xml</relativePath>
 	</parent>
 
 	<artifactId>examples</artifactId>

--- a/examples/v2c/pom.xml
+++ b/examples/v2c/pom.xml
@@ -1,51 +1,52 @@
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
-	<modelVersion>4.0.0</modelVersion>
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+    <modelVersion>4.0.0</modelVersion>
 
-	<parent>
-		<groupId>com.fujitsu</groupId>
-		<artifactId>examples</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
-	</parent>
-	
-	<artifactId>v2c</artifactId>
-	<name>V2C</name>
-	<description>Example VDM to C class mapper implementation</description>
-	
-	<dependencies>
-		<dependency>
-			<groupId>junit</groupId>
-			<artifactId>junit</artifactId>
-			<version>4.12</version>
-			<scope>test</scope>
-		</dependency>
-		<dependency>
-			<groupId>com.fujitsu</groupId>
-			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
-		</dependency>
-		<dependency>
-			<groupId>com.fujitsu</groupId>
-			<artifactId>lsp</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
-		</dependency>
-	</dependencies>
+    <parent>
+        <groupId>dk.au.ece.vdmj</groupId>
+        <artifactId>examples</artifactId>
+        <version>${revision}${sha1}${changelist}</version>
+        <relativePath>../pom.xml</relativePath>
+    </parent>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-compiler-plugin</artifactId>
-				<version>2.3.2</version>
-				<configuration>
-					<source>1.8</source>
-					<target>1.8</target>
-				</configuration>
-			</plugin>
-			<plugin>
-				<artifactId>maven-jar-plugin</artifactId>
-				<version>2.3.2</version>
+    <artifactId>v2c</artifactId>
+    <name>V2C</name>
+    <description>Example VDM to C class mapper implementation</description>
+
+    <dependencies>
+        <dependency>
+            <groupId>junit</groupId>
+            <artifactId>junit</artifactId>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>dk.au.ece.vdmj</groupId>
+            <artifactId>vdmj</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+        <dependency>
+            <groupId>dk.au.ece.vdmj</groupId>
+            <artifactId>lsp</artifactId>
+            <version>${project.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <plugins>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-compiler-plugin</artifactId>
+                <version>2.3.2</version>
+                <configuration>
+                    <source>1.8</source>
+                    <target>1.8</target>
+                </configuration>
+            </plugin>
+            <plugin>
+                <artifactId>maven-jar-plugin</artifactId>
+                <version>2.3.2</version>
                 <executions>
                     <execution>
                         <id>default-jar</id>
@@ -54,13 +55,13 @@
                             <goal>jar</goal>
                         </goals>
                         <configuration>
-							<finalName>
-								${project.artifactId}-${project.version}-${maven.build.timestamp}
-							</finalName>
-						</configuration>
-					</execution>
-				</executions>
-			</plugin>
-		</plugins>
-	</build>
+                            <finalName>
+                                ${project.artifactId}-${project.version}-${maven.build.timestamp}
+                            </finalName>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
 </project>

--- a/lsp/pom.xml
+++ b/lsp/pom.xml
@@ -7,9 +7,9 @@
 	<description>VDMJ LSP Server</description>
 	
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -32,9 +32,9 @@
 			<scope>test</scope>
 		</dependency>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -1,85 +1,268 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <project xmlns="http://maven.apache.org/POM/4.0.0"
-	xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
-	xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
 
-	<modelVersion>4.0.0</modelVersion>
+    <modelVersion>4.0.0</modelVersion>
 
-	<groupId>com.fujitsu</groupId>
-	<artifactId>vdmj-suite</artifactId>
-	<name>VDMJ Suite</name>
-	<packaging>pom</packaging>
-	<version>4.4.5</version><!--UPDATE-->	<!-- This version is inherited by all modules -->
-	
-	<properties>
-	    <maven.build.timestamp.format>yyMMdd</maven.build.timestamp.format>
-	    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
-	</properties>
+    <groupId>dk.au.ece.vdmj</groupId>
+    <artifactId>vdmj-suite</artifactId>
+    <name>VDMJ Suite</name>
+    <packaging>pom</packaging>
+    <version>${revision}${sha1}${changelist}</version>
 
-	<!-- sub modules -->
-	<modules>
-		<module>annotations</module>
-		<module>annotations2</module>
-		<module>vdmj</module>
-		<module>vdmjunit</module>
-		<module>lsp</module>
-		<module>dbgp</module>
-		<module>dbgpc</module>
-		<module>stdlib</module>
-		<module>cmd-plugins</module>
-		<module>examples</module>
-	</modules>
+    <properties>
+        <maven.build.timestamp.format>yyMMdd</maven.build.timestamp.format>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
 
-	<build>
-		<plugins>
-			<plugin>
-				<groupId>org.apache.maven.plugins</groupId>
-				<artifactId>maven-release-plugin</artifactId>
-				<version>2.5.1</version>
-				<configuration>
-					<goals>deploy</goals>
-				</configuration>
-			</plugin>
-			<plugin>
-				<groupId>org.sonatype.plugins</groupId>
-				<artifactId>nexus-staging-maven-plugin</artifactId>
-				<version>1.6.12</version>
-				<extensions>true</extensions>
-				<configuration>
-					<serverId>ossrh</serverId>
-					<nexusUrl>https://oss.sonatype.org/</nexusUrl>
-					<!--autoReleaseAfterClose>true</autoReleaseAfterClose -->
-				</configuration>
-			</plugin>			
-		</plugins>
-	</build>
+        <revision>4.4.5</revision>
+        <changelist>-SNAPSHOT</changelist>
+        <sha1/>
+    </properties>
 
-	<distributionManagement>
-	    <repository>
-	        <id>vdmj.overture.au.dk-central</id>
-	        <name>overture.au.dk-releases</name>
-	        <url>https://overture.au.dk/artifactory/vdmj</url>
-	    </repository>
-	    <snapshotRepository>
-	        <id>vdmj.overture.au.dk-snapshots</id>
-	        <name>overture.au.dk-snapshots</name>
-	        <url>https://overture.au.dk/artifactory/vdmj</url>
-	    </snapshotRepository>
-<!--
-	    <repository>
-		<id>ossrh</id>
-		<url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
-	    </repository>
-	    <snapshotRepository>
-		<id>ossrh</id>
-		<url>https://oss.sonatype.org/content/repositories/snapshots</url>
-	    </snapshotRepository>
--->
-	</distributionManagement>
+    <!-- sub modules -->
+    <modules>
+        <module>annotations</module>
+        <module>annotations2</module>
+        <module>vdmj</module>
+        <module>vdmjunit</module>
+        <module>lsp</module>
+        <module>dbgp</module>
+        <module>dbgpc</module>
+        <module>stdlib</module>
+        <module>cmd-plugins</module>
+        <module>examples</module>
+    </modules>
 
-	<scm>
-		<connection>scm:git:https://github.com/nickbattle</connection>
-		<developerConnection>scm:git:https://github.com/nickbattle</developerConnection>
-	</scm>
+    <build>
+        <pluginManagement>
+            <plugins>
+                <!-- Configure the compiler for all Overture Projects -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-compiler-plugin</artifactId>
+                    <version>3.10.1</version>
+                </plugin>
+
+
+                <!-- Attatch sources to all installed jars -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>3.2.1</version>
+                    <executions>
+                        <execution>
+                            <id>attach-sources</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <attach>true</attach>
+                    </configuration>
+                </plugin>
+
+                <!-- Enable JavaDoc but dont fail on error. This must be disabled for
+                     the Eclipse project in the IDE -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-javadoc-plugin</artifactId>
+                    <version>3.3.2</version>
+                    <executions>
+                        <execution>
+                            <id>attach-javadocs</id>
+                            <goals>
+                                <goal>jar</goal>
+                            </goals>
+                        </execution>
+                    </executions>
+                    <configuration>
+                        <failOnError>false</failOnError>
+                        <quiet>true</quiet>
+                    </configuration>
+                </plugin>
+
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-resources-plugin</artifactId>
+                    <version>3.1.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-surefire-plugin</artifactId>
+                    <version>3.0.0-M6</version>
+
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-dependency-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-assembly-plugin</artifactId>
+                    <version>3.3.0</version>
+                </plugin>
+
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-install-plugin</artifactId>
+                    <version>3.0.0-M1</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-deploy-plugin</artifactId>
+                    <version>3.0.0-M2</version>
+                </plugin>
+
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jar-plugin</artifactId>
+                    <version>3.2.2</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-clean-plugin</artifactId>
+                    <version>3.2.0</version>
+                </plugin>
+
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-jarsigner-plugin</artifactId>
+                    <version>3.0.0</version>
+                </plugin>
+
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-gpg-plugin</artifactId>
+                    <version>3.0.1</version>
+                </plugin>
+
+
+            </plugins>
+        </pluginManagement>
+    </build>
+
+    <scm>
+        <url>https://github.com/nickbattle/vdmj
+        </url>
+        <connection>scm:git:https://github.com/nickbattle</connection>
+        <developerConnection>scm:git:https://github.com/nickbattle</developerConnection>
+    </scm>
+
+    <url>https://github.com/nickbattle/vdmj</url>
+
+    <description>VDMJ provides basic tool support for the VDM-SL, VDM++ and VDM-RT specification languages, written in
+        Java. It includes a parser, a type checker, an interpreter (with arbitrary precision arithmetic), a debugger, a
+        proof obligation generator and a combinatorial test generator with coverage recording, as well as JUnit support
+        for automatic testing and user definable annotations.
+    </description>
+
+    <developers>
+        <developer>
+            <id>NickBattle</id>
+            <name>Nick Battle</name>
+            <email>nick.battle@gmail.com</email>
+            <roles>
+                <role>developer</role>
+            </roles>
+        </developer>
+    </developers>
+
+    <licenses>
+        <license>
+            <name>GPL-3.0</name>
+            <url>https://github.com/nickbattle/vdmj/blob/master/LICENCE</url>
+        </license>
+    </licenses>
+
+    <profiles>
+        <profile>
+            <id>release</id>
+            <activation>
+                <property>
+                    <name>performRelease</name>
+                    <value>true</value>
+                </property>
+            </activation>
+            <distributionManagement>
+                <snapshotRepository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/content/repositories/snapshots</url>
+                </snapshotRepository>
+                <repository>
+                    <id>ossrh</id>
+                    <url>https://oss.sonatype.org/service/local/staging/deploy/maven2/</url>
+                </repository>
+            </distributionManagement>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-javadoc-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-source-plugin</artifactId>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.sonatype.plugins</groupId>
+                        <artifactId>nexus-staging-maven-plugin</artifactId>
+                        <version>1.6.12</version>
+                        <extensions>true</extensions>
+                        <configuration>
+                            <serverId>ossrh</serverId>
+                            <nexusUrl>https://s01.oss.sonatype.org</nexusUrl>
+                            <!--autoReleaseAfterClose>true</autoReleaseAfterClose-->
+                            <autoReleaseAfterClose>false</autoReleaseAfterClose>
+                        </configuration>
+                    </plugin>
+                    <plugin>
+                        <groupId>org.apache.maven.plugins</groupId>
+                        <artifactId>maven-gpg-plugin</artifactId>
+                        <executions>
+                            <execution>
+                                <id>sign-artifacts</id>
+                                <phase>verify</phase>
+                                <goals>
+                                    <goal>sign</goal>
+                                </goals>
+                            </execution>
+                        </executions>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
+        <profile>
+            <id>au</id>
+            <activation>
+                <activeByDefault>true</activeByDefault>
+            </activation>
+            <distributionManagement>
+                <repository>
+                    <id>vdmj.overture.au.dk-central</id>
+                    <name>overture.au.dk-releases</name>
+                    <url>https://overture.au.dk/artifactory/vdmj</url>
+                </repository>
+                <snapshotRepository>
+                    <id>vdmj.overture.au.dk-snapshots</id>
+                    <name>overture.au.dk-snapshots</name>
+                    <url>https://overture.au.dk/artifactory/vdmj</url>
+                </snapshotRepository>
+            </distributionManagement>
+        </profile>
+
+    </profiles>
 
 </project>

--- a/stdlib/pom.xml
+++ b/stdlib/pom.xml
@@ -4,9 +4,9 @@
 	<name>Standard Libraries</name>
 
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -17,9 +17,9 @@
 			<version>4.8.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 

--- a/vdmj/pom.xml
+++ b/vdmj/pom.xml
@@ -5,9 +5,9 @@
 	<name>VDMJ</name>
 	
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 

--- a/vdmjunit/pom.xml
+++ b/vdmjunit/pom.xml
@@ -5,9 +5,9 @@
 	<name>VDMJUnit</name>
 	
 	<parent>
-		<groupId>com.fujitsu</groupId>
+		<groupId>dk.au.ece.vdmj</groupId>
 		<artifactId>vdmj-suite</artifactId>
-		<version>4.4.5</version><!--UPDATE-->
+		<version>${revision}${sha1}${changelist}</version>
 		<relativePath>../pom.xml</relativePath>
 	</parent>
 
@@ -31,9 +31,9 @@
 			<version>4.8.2</version>
 		</dependency>
 		<dependency>
-			<groupId>com.fujitsu</groupId>
+			<groupId>dk.au.ece.vdmj</groupId>
 			<artifactId>vdmj</artifactId>
-			<version>4.4.5</version><!--UPDATE-->
+			<version>${project.version}</version>
 		</dependency>
 	</dependencies>
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/2575418/178454891-d9bdb929-98b9-47d4-8938-b3ffa7dae405.png)

This change includes:

- Upgrade of the main maven plugins to a newer version (they were very old) and configures sources and javadoc
- Adds the nessesary properties in the root pom to make it pass the sonatype checks
- Changes to the groupid to `dk.au.ece.vdmj`
- Changes the way versions are set. Not all dependencies are project version relative. A build now has a default version committed in the root pom. If one would like to override it then all properties can be set on the cli like: ` mvn clean deploy -Prelease -Dchangelist= ` this would release the current version as a release. If it was a snapshot build for a feature branch one could do ` mvn clean package -Dchangelist=-SNAPSHOT -Dsha1=my-feature -Drevision=1.2.3` (probably leave out the version)
- Added two new profiles `au` and `release` au is active by default and works like before. `release` configures the build for a sonatype release by attaching sources, javadoc and uses the sonatype plugin for handling the staging env. We can comment the autoRelease and set this on the cli so control if is should release it if all tests pass.