### PR TITLE
Experimenting with file input in standard library

### DIFF
--- a/stdlib/src/main/java/CSV.java
+++ b/stdlib/src/main/java/CSV.java
@@ -123,7 +123,7 @@ public class CSV implements Serializable
 	}
 
 	/**
-	 * Read a CSV live as a seq of ? in VDM
+	 * Read a CSV line as a seq of ? in VDM
 	 * 
 	 * @param fval
 	 *            name of the file to read from

--- a/stdlib/src/main/java/IO.java
+++ b/stdlib/src/main/java/IO.java
@@ -24,8 +24,10 @@
 
 // This must be in the default package to work with VDMJ's native delegation.
 
+import java.io.BufferedReader;
 import java.io.File;
 import java.io.FileOutputStream;
+import java.io.FileReader;
 import java.io.IOException;
 import java.io.Serializable;
 
@@ -167,6 +169,51 @@ public class IO implements Serializable
 		}
 
 		return new BooleanValue(true);
+	}
+
+	@VDMOperation
+	public static Value finput(Value fval)
+	{
+		ValueList result = new ValueList();
+
+		try
+		{
+			File file = new File(stringOf(fval).replace('/', File.separatorChar));
+			if (!file.isAbsolute())
+			{
+				file = new File(new File(".").getParentFile(), file.getAbsolutePath());
+			}
+
+			BufferedReader bufferedReader = new BufferedReader(new FileReader(file));
+			ValueList valList = new ValueList();
+			boolean isReadingFile = true;
+
+			while(isReadingFile) {
+				int nextCharacterInt = bufferedReader.read();
+
+				if(nextCharacterInt == -1) {
+					isReadingFile = false;
+					break;
+				}
+
+				CharacterValue cv = new CharacterValue((char) nextCharacterInt);
+				valList.add(cv);
+			}
+
+			bufferedReader.close();
+			SeqValue seqVal = new SeqValue(valList);
+			result.add(new BooleanValue(true));
+			result.add(seqVal);
+		}
+		catch (Exception e)
+		{
+			lastError = e.toString();
+			result = new ValueList();
+			result.add(new BooleanValue(false));
+			result.add(new NilValue());
+		}
+
+		return new TupleValue(result);
 	}
 
 	@VDMOperation

--- a/stdlib/src/main/resources/IO.vdmpp
+++ b/stdlib/src/main/resources/IO.vdmpp
@@ -59,6 +59,13 @@ fecho (filename,text,fdir) ==
   is not yet specified
   pre filename = "" <=> fdir = nil;
 
+-- Get input text from a file, similar to the reverse of fecho
+public
+finput: seq1 of char ==> bool * [seq of char]
+finput (filename) ==
+  is not yet specified
+  post let mk_(b,t) = RESULT in not b => t = nil;
+
 -- The in/out functions  will return false if an error occur. In this
 -- case an internal error string will be set. 'ferror' returns this
 -- string and set it to "".

--- a/stdlib/src/main/resources/IO.vdmrt
+++ b/stdlib/src/main/resources/IO.vdmrt
@@ -59,6 +59,13 @@ fecho (filename,text,fdir) ==
   is not yet specified
   pre filename = "" <=> fdir = nil;
 
+-- Get input text from a file, similar to the reverse of fecho
+public
+finput: seq1 of char ==> bool * [seq of char]
+finput (filename) ==
+  is not yet specified
+  post let mk_(b,t) = RESULT in not b => t = nil;
+
 -- The in/out functions  will return false if an error occur. In this
 -- case an internal error string will be set. 'ferror' returns this
 -- string and set it to "".

--- a/stdlib/src/main/resources/IO.vdmsl
+++ b/stdlib/src/main/resources/IO.vdmsl
@@ -55,6 +55,12 @@ fecho (filename,text,fdir) ==
   is not yet specified
   pre filename = "" <=> fdir = nil;
 
+-- Get input text from a file, similar to the reverse of fecho
+finput: seq1 of char ==> bool * [seq of char]
+finput (filename) ==
+  is not yet specified
+  post let mk_(b,t) = RESULT in not b => t = nil;
+
 -- The in/out functions  will return false if an error occur. In this
 -- case an internal error string will be set. 'ferror' returns this
 -- string and set it to "".


### PR DESCRIPTION
Hi,

I was wondering if there was any thoughts on extending the standard library to allow reading arbitrary strings from files.

The standard library already contains CSV reading tools, as well as arbitrary writing of a seq of char to files through the fecho functions. It also allows the reading of vdm values from files through freadval.

Obviously file reading/writing is something that VDM would have trouble with naturally without the aid of the Java standard library adapters, so a pure VDM library is not an option.

Additionally it would seem natural to want to interact with config/data files (as shown by the presence of the CSV and IO file functions), and the ability to read in an arbitrary string from a file gives the most flexibility. This could open the door to allow one to work with popular, modern data file formats such as JSON, YAML, and XML in VDM itself.